### PR TITLE
feat(typings): adapt errors object to have all fields of values type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -217,7 +217,7 @@ export type DefaultError<
   ValuesType extends object,
   V extends Validations<ValuesType>
 > = {
-  [K in keyof V]?: DefaultValidationReturnType<V[K]>;
+  [K in keyof ValuesType]?: DefaultValidationReturnType<V[K]>;
 };
 
 export type DefaultValidationReturnType<


### PR DESCRIPTION
Fields in the errors object that have no validation specified will always have type undefined.
This will allow code to be more flexible.