### PR TITLE
fix(form-config): change context type from `any` to `object`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -52,8 +52,8 @@
   - [Description](#description-3)
   - [Generic types](#generic-types-2)
   - [Members](#members-2)
-    - [`abstract validateField: <K extends keyof ValuesType>(field: K, values: ValuesType, context?: any) => Errors[K] | void`](#abstract-validatefield-k-extends-keyof-valuestypefield-k-values-valuestype-context-any--errorsk--void)
-    - [`validateAllFields: (values: ValuesType, context?: any) => Errors`](#validateallfields-values-valuestype-context-any--errors)
+    - [`abstract validateField: <K extends keyof ValuesType>(field: K, values: ValuesType, context: object) => Errors[K] | void`](#abstract-validatefield-k-extends-keyof-valuestypefield-k-values-valuestype-context-object--errorsk--void)
+    - [`validateAllFields: (values: ValuesType, context: object) => Errors`](#validateallfields-values-valuestype-context-object--errors)
 - [`FormConfig`](#formconfig)
   - [Type](#type-5)
   - [Description](#description-4)
@@ -64,7 +64,7 @@
     - [`validateOnSubmit: () => FormConfig`](#validateonsubmit---formconfig)
     - [`validateOnContextChange: (validate: boolean = true) => FormConfig`](#validateoncontextchange-validate-boolean--true--formconfig)
     - [`withInitialValues: (values: Partial<ValuesType>) => FormConfig`](#withinitialvalues-values-partialvaluestype--formconfig)
-    - [`withContext: (context: any) => FormConfig`](#withcontext-context-any--formconfig)
+    - [`withContext: (context: object) => FormConfig`](#withcontext-context-object--formconfig)
     - [`withValidation: (validations: Validations) => FormConfig`](#withvalidation-validations-validations--formconfig)
     - [`withCustomValidator: (validator: Validator) => FormConfig`](#withcustomvalidator-validator-validator--formconfig)
 - [`useFluentForm`](#usefluentform)
@@ -75,12 +75,12 @@
     - [`touched: StateTouched`](#touched-statetouched)
     - [`validity: StateValidity`](#validity-statevalidity)
     - [`errors: ErrorsType<ValuesType, ErrorType>`](#errors-errorstypevaluestype-errortype)
-    - [`context: any`](#context-any)
+    - [`context: object`](#context-object)
     - [`submitting: boolean`](#submitting-boolean)
     - [`fields: Fields<ValuesType>`](#fields-fieldsvaluestype)
     - [`setValues: (values: Partial<ValuesType>) => void`](#setvalues-values-partialvaluestype--void)
     - [`setInitialValues: (values: Partial<ValuesType>) => void`](#setinitialvalues-values-partialvaluestype--void)
-    - [`setContext: (context: Partial<ValuesType>) => void`](#setcontext-context-partialvaluestype--void)
+    - [`setContext: (context: object) => void`](#setcontext-context-object--void)
     - [`handleSubmit: (success?: Function, failure?: Function, options?: HandleSubmitOptions) => (event: any) => void`](#handlesubmit-success-function-failure-function-options-handlesubmitoptions--event-any--void)
     - [`reset: () => void`](#reset---void)
 
@@ -334,11 +334,11 @@ Type of errors object. Needs to extend `ErrorsType`.
 
 ### Members
 
-#### `abstract validateField: <K extends keyof ValuesType>(field: K, values: ValuesType, context?: any) => Errors[K] | void`
+#### `abstract validateField: <K extends keyof ValuesType>(field: K, values: ValuesType, context: object) => Errors[K] | void`
 
 Validates one form field and returns validation error for field in case of validation failure else nothing. Needs to be overriden when custom validator is required.
 
-#### `validateAllFields: (values: ValuesType, context?: any) => Errors`
+#### `validateAllFields: (values: ValuesType, context: object) => Errors`
 
 Validates all fields based on `validateField`. Can be overriden to e.g. improve performance.
 
@@ -395,9 +395,9 @@ const formConfig = createForm<UserForm>()({
 }).withInitialValues({ email: "email@example.com" });
 ```
 
-#### `withContext: (context: any) => FormConfig`
+#### `withContext: (context: object) => FormConfig`
 
-Sets the initial context value. It needs to be an object of any type.  
+Sets the initial context value. It needs to be an **object** of any type.  
  It's recommend to wrap your context values in a `context` field (s. `withValidation` below for more details):
 
 ```ts
@@ -474,7 +474,7 @@ export class RequiredValidator<ValuesType> extends Validator<
   public validateField<K extends keyof ValuesType>(
     field: K,
     values: ValuesType,
-    _context: any // not relevant for this example
+    _context: object // not relevant for this example
   ) {
     if (this.requiredFields[field] && !values[field]) {
       return "field is required";
@@ -591,9 +591,9 @@ Possible values for each field:
 }
 ```
 
-#### `context: any`
+#### `context: object`
 
-Current context value. Initial value is `undefined`.
+Current context value. Initial value is `{}`.
 
 #### `submitting: boolean`
 
@@ -627,7 +627,7 @@ Sets values of form.
 
 Sets initial values of form. This is important when resetting a form.
 
-#### `setContext: (context: Partial<ValuesType>) => void`
+#### `setContext: (context: object) => void`
 
 Updates value of validation context. To re-validate all fields on context change `FormConfig.validateOnContextChange` can be used.
 Works well in combinations with `useEffect`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,9 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/test/setupTests.ts"],
   globals: {
     "ts-jest": {
-      tsConfig: "tsconfig.test.json"
+      tsConfig: {
+        noUnusedLocals: false
+      }
     }
   }
 };

--- a/src/form-config/FormArrayConfigHelper.ts
+++ b/src/form-config/FormArrayConfigHelper.ts
@@ -28,7 +28,7 @@ export class FormArrayConfigHelper<Config extends FormArrayConfig = any> {
         touched: {},
         validity: {},
         errors: {} as Errors,
-        context: undefined,
+        context: {},
         submitting: false
       };
     }

--- a/src/form-config/FormConfigHelper.ts
+++ b/src/form-config/FormConfigHelper.ts
@@ -21,7 +21,7 @@ export class FormConfigHelper<Config extends FormConfig = any> {
 
   public getValidationResultForAllFields(
     values: ExtractValuesType<Config>,
-    context: any
+    context: object
   ): ExtractErrorsType<Config> {
     if (this.formConfig._validator) {
       return this.formConfig._validator.validateAllFields(values, context);
@@ -34,7 +34,7 @@ export class FormConfigHelper<Config extends FormConfig = any> {
     field: K,
     value: ExtractValuesType<Config>[K],
     values: ExtractValuesType<Config>,
-    context: any
+    context: object
   ): ExtractErrorsType<Config>[K] {
     if (this.formConfig._validator) {
       const error = this.formConfig._validator.validateField(

--- a/src/hooks/fluent-form-array/state-manager/reducer.ts
+++ b/src/hooks/fluent-form-array/state-manager/reducer.ts
@@ -34,7 +34,7 @@ export type FluentFormArrayActionTypes<
       { key: FormKey; field: K; value: ValuesType[K]; touched?: boolean }
     >
   | Action<"SET_SINGLE_TOUCHED", { key: FormKey; field: K; touched?: boolean }>
-  | Action<"SET_CONTEXT", { key: FormKey; context: any }>
+  | Action<"SET_CONTEXT", { key: FormKey; context: object }>
   | Action<
       "VALUE_CHANGE",
       { key: FormKey; field: K; value: ValuesType[K]; touched?: boolean }

--- a/src/hooks/fluent-form-array/state-manager/useFluentArrayStateManager.ts
+++ b/src/hooks/fluent-form-array/state-manager/useFluentArrayStateManager.ts
@@ -62,7 +62,7 @@ export function useFluentArrayStateManager<Config extends FormArrayConfig>(
         touched: {},
         validity: {},
         errors: {} as Errors,
-        context: _context,
+        context: _context || {},
         submitting: false
       };
 
@@ -107,7 +107,7 @@ export function useFluentArrayStateManager<Config extends FormArrayConfig>(
     []
   );
 
-  const setContext = useCallback((key: FormKey, context: any) => {
+  const setContext = useCallback((key: FormKey, context: object) => {
     dispatch({ type: "SET_CONTEXT", payload: { key, context } });
   }, []);
 

--- a/src/hooks/fluent-form/state-manager/reducer.ts
+++ b/src/hooks/fluent-form/state-manager/reducer.ts
@@ -15,7 +15,7 @@ export type FluentFormActionTypes<
       { field: K; value: ValuesType[K]; touched?: boolean }
     >
   | Action<"SET_SINGLE_TOUCHED", { field: K; touched?: boolean }>
-  | Action<"SET_CONTEXT", { context: any }>
+  | Action<"SET_CONTEXT", { context: object }>
   | Action<
       "VALUE_CHANGE",
       { field: K; value: ValuesType[K]; touched?: boolean }

--- a/src/hooks/fluent-form/state-manager/useFluentStateManager.ts
+++ b/src/hooks/fluent-form/state-manager/useFluentStateManager.ts
@@ -29,7 +29,7 @@ export function useFluentStateManager<Config extends FormConfig>(
     touched: {},
     validity: {},
     errors: {} as Errors,
-    context: _context,
+    context: _context || {},
     submitting: false
   });
 
@@ -38,7 +38,7 @@ export function useFluentStateManager<Config extends FormConfig>(
     intitalStateRef.current
   );
 
-  const setContext = useCallback((context: any) => {
+  const setContext = useCallback((context: object) => {
     dispatch({ type: "SET_CONTEXT", payload: { context } });
   }, []);
 

--- a/src/hooks/fluent-form/useFluentFormBase.ts
+++ b/src/hooks/fluent-form/useFluentFormBase.ts
@@ -47,7 +47,7 @@ export function useFluentFormBase<Config extends FormConfig>(
   );
 
   const setContext = useCallback(
-    (context: any) => {
+    (context: object) => {
       setContextState(context);
       if (_validateOnContextChange) {
         validateAllFields(context);

--- a/src/hooks/helper/useStateManagerMapper.ts
+++ b/src/hooks/helper/useStateManagerMapper.ts
@@ -36,7 +36,7 @@ export function useStateManagerMapper<Config extends FormArrayConfig>(
   );
 
   const setContext = useCallback(
-    (context: any) => setContextWithKey(key, context),
+    (context: object) => setContextWithKey(key, context),
     [key, setContextWithKey]
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,12 +17,12 @@ export interface UseFluentForm<Config extends FormConfig> {
   touched: StateTouched<ExtractValuesType<Config>>;
   validity: StateValidity<ExtractValuesType<Config>>;
   errors: ExtractErrorsType<Config>;
-  context: any;
+  context: object;
   submitting: boolean;
   fields: MappedFields<ExtractFieldsType<Config>>;
   setValues: (values: Partial<ExtractValuesType<Config>>) => void;
   setInitialValues: (values: Partial<ExtractValuesType<Config>>) => void;
-  setContext: (context: any) => void;
+  setContext: (context: object) => void;
   handleSubmit: HandleSubmit;
   reset: () => void;
 }
@@ -47,7 +47,7 @@ export interface FluentFormState<
   touched: StateTouched<ValuesType>;
   validity: StateValidity<ValuesType>;
   errors: Errors;
-  context: any;
+  context: object;
   submitting: boolean;
 }
 
@@ -71,7 +71,7 @@ export type SetTouched = (value?: boolean) => void;
 export interface UseFluentStateManager<Config extends FormConfig> {
   formConfigHelperRef: React.MutableRefObject<FormConfigHelper<Config>>;
   state: FluentFormState<ExtractValuesType<Config>, ExtractErrorsType<Config>>;
-  setContext: (context: any) => void;
+  setContext: (context: object) => void;
   setInitialValuesRef: (values: Partial<ExtractValuesType<Config>>) => void;
   setSubmittingResult: (errors: ExtractErrorsType<Config>) => void;
   setTouched: <K extends keyof ExtractFieldsType<Config>>(
@@ -183,7 +183,7 @@ export interface UseFluentArrayStateManager<Config extends FormArrayConfig> {
   setSubmittingResultForArray: (
     errors: FormArrayError<ExtractErrorsType<Config>>
   ) => void;
-  setContext: (key: FormKey, context: any) => void;
+  setContext: (key: FormKey, context: object) => void;
   setInitialValuesRef: (
     key: FormKey,
     values: Partial<ExtractValuesType<Config>>
@@ -361,11 +361,12 @@ export interface RawProps<V> {
 export type ValidateFunction<
   ValuesType,
   K extends keyof ValuesType,
-  Error = unknown
+  Error = unknown,
+  Context extends object = any
 > = (
   value: ValuesType[K],
   values: ValuesType,
-  context: any
+  context: Context
 ) => yup.Schema<any> | Error | undefined;
 
 export type Validations<ValuesType> = {
@@ -395,7 +396,7 @@ export interface ValidateYupSchemaArgs<ValuesType, K extends keyof ValuesType> {
   value: ValuesType[K];
   values: ValuesType;
   schema: yup.Schema<any>;
-  context: any;
+  context: object;
 }
 
 export interface ValidateFunctionArgs<
@@ -406,7 +407,7 @@ export interface ValidateFunctionArgs<
   value: ValuesType[K];
   values: ValuesType;
   validate: ValidateFunction<ValuesType, K, Error>;
-  context: any;
+  context: object;
 }
 
 // -------------------- HandleSubmit --------------------

--- a/src/validation/DefaultValidator.ts
+++ b/src/validation/DefaultValidator.ts
@@ -63,7 +63,7 @@ export class DefaultValidator<
   public validateField<K extends keyof ValuesType>(
     field: K,
     values: ValuesType,
-    context?: any
+    context: object = {}
   ): DefaultValidationReturnType<V[K]> | void {
     const validate = this.validations[field];
     const value = values[field];

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -7,10 +7,10 @@ export abstract class Validator<
   public abstract validateField<K extends keyof ValuesType>(
     field: K,
     values: ValuesType,
-    context?: any
+    context: object
   ): Errors[K] | void;
 
-  public validateAllFields(values: ValuesType, context?: any): Errors {
+  public validateAllFields(values: ValuesType, context: object): Errors {
     const fields = Object.keys(values) as (keyof ValuesType)[];
 
     return fields.reduce(

--- a/test/DefaultValidator.test.ts
+++ b/test/DefaultValidator.test.ts
@@ -21,22 +21,20 @@ describe("DefaultValidator", () => {
 
     validator.validateField = jest.fn(() => 1) as any;
 
-    const result = validator.validateAllFields(testModel, "context");
+    const result = validator.validateAllFields(testModel, {
+      context: "context"
+    });
 
     expect(result).toMatchObject({
       aString: 1,
       aDate: 1
     });
-    expect(validator.validateField).toHaveBeenCalledWith(
-      "aString",
-      testModel,
-      "context"
-    );
-    expect(validator.validateField).toHaveBeenCalledWith(
-      "aDate",
-      testModel,
-      "context"
-    );
+    expect(validator.validateField).toHaveBeenCalledWith("aString", testModel, {
+      context: "context"
+    });
+    expect(validator.validateField).toHaveBeenCalledWith("aDate", testModel, {
+      context: "context"
+    });
   });
 
   describe("validateField", () => {

--- a/test/FormArrayConfigHelper.test.ts
+++ b/test/FormArrayConfigHelper.test.ts
@@ -49,7 +49,7 @@ describe("FormConfigHelper", () => {
           validity: {},
           errors: {},
           submitting: false,
-          context: undefined
+          context: {}
         },
         "1": {
           key: 1,
@@ -59,7 +59,7 @@ describe("FormConfigHelper", () => {
           validity: {},
           errors: {},
           submitting: false,
-          context: undefined
+          context: {}
         }
       });
     });

--- a/test/useFluentFormArray.test.tsx
+++ b/test/useFluentFormArray.test.tsx
@@ -339,7 +339,7 @@ describe("useFluentFormArray", () => {
           touched: { username: true, email: true },
           validity: { username: true, email: true },
           errors: { username: undefined, email: undefined },
-          context: undefined,
+          context: {},
           submitting: false
         },
         {
@@ -352,7 +352,7 @@ describe("useFluentFormArray", () => {
           touched: { username: true, email: true },
           validity: { username: true, email: true },
           errors: { username: undefined, email: undefined },
-          context: undefined,
+          context: {},
           submitting: false
         }
       ]);
@@ -386,7 +386,7 @@ describe("useFluentFormArray", () => {
           touched: { username: true, email: true },
           validity: { username: false, email: true },
           errors: { username: expect.any(Array), email: undefined },
-          context: undefined,
+          context: {},
           submitting: false
         },
         {
@@ -399,7 +399,7 @@ describe("useFluentFormArray", () => {
           touched: { username: true, email: true },
           validity: { username: false, email: true },
           errors: { username: expect.any(Array), email: undefined },
-          context: undefined,
+          context: {},
           submitting: false
         }
       ]);

--- a/test/useFluentFormItem-multiple.test.tsx
+++ b/test/useFluentFormItem-multiple.test.tsx
@@ -335,7 +335,7 @@ describe("useFluentFormItem (multiple)", () => {
       });
       expect(formItemContext1).toEqual(formArrayContext1);
 
-      expect(formArrayContext0).toEqual(undefined);
+      expect(formArrayContext0).toEqual({});
       expect(formItemContext0).toEqual(formArrayContext0);
       expect(formArrayContext2).toEqual(formArrayContext0);
       expect(formItemContext2).toEqual(formArrayContext0);

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noUnusedLocals": false
-  }
-}


### PR DESCRIPTION
Context was mistakenly declared as type any, but it should always be of type object.
This is required since it will be spreaded into the context of yup validation schemes.
Initial value was changes from "undefined" to "{}"