### PR TITLE
ci(dev): fix pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with: 
+          persist-credentials: false
       - uses: actions/setup-node@v2
         with:
           node-version: "14"


### PR DESCRIPTION
semantic release bot was unable to push to master athough GITHUB_TOKEN has correct perimission set